### PR TITLE
Add google sign up form instead of slack link

### DIFF
--- a/index.html
+++ b/index.html
@@ -278,8 +278,8 @@
             <div class="row">
                 <div class="col-lg-8 col-lg-offset-2">
                    <p>We're a friendly and inclusive bunch, and we'd like to help you get plugged into a community of people from all kinds of backgrounds who share a common interest in tackling the climate crisis.</p>
-                   <p>To join, sign up <a href="https://docs.google.com/forms/d/e/1FAIpQLSdtvNeUkNkPybk9_Ln5klL1RUPHUCwfK4OfF-odRWnHME9d-g/viewform">using this form</a>, and we'll add you to the slack community.</p>
-                   <p>You can also email us at <a href="mailto:hello@climateaction.tech?Subject=Hello!">hello@climateaction.tech</a>. </p>
+                   <p>To join, <a href="https://docs.google.com/forms/d/e/1FAIpQLSdtvNeUkNkPybk9_Ln5klL1RUPHUCwfK4OfF-odRWnHME9d-g/viewform"> fill out this sign up form</a> and we'll add you to the slack community.</p>
+                   <p>You can also <a href="mailto:hello@climateaction.tech?Subject=Hello!">email us at hello@climateaction.tech</a>. </p>
                 </div>
             </div>
         </div>

--- a/index.html
+++ b/index.html
@@ -278,8 +278,8 @@
             <div class="row">
                 <div class="col-lg-8 col-lg-offset-2">
                    <p>We're a friendly and inclusive bunch, and we'd like to help you get plugged into a community of people from all kinds of backgrounds who share a common interest in tackling the climate crisis.</p>
-                   <p>To join, sign up <a href="https://docs.google.com/forms/d/e/1FAIpQLSdtvNeUkNkPybk9_Ln5klL1RUPHUCwfK4OfF-odRWnHME9d-g/viewform">here</a>, and we'll add you to the slack community.</p>
-                   <p>If you just want to get in touch, you can also email us at <a href="mailto:hello@climateaction.tech?Subject=Hello!">hello@climateaction.tech</a>. </p>
+                   <p>To join, sign up <a href="https://docs.google.com/forms/d/e/1FAIpQLSdtvNeUkNkPybk9_Ln5klL1RUPHUCwfK4OfF-odRWnHME9d-g/viewform">using this form</a>, and we'll add you to the slack community.</p>
+                   <p>You can also email us at <a href="mailto:hello@climateaction.tech?Subject=Hello!">hello@climateaction.tech</a>. </p>
                 </div>
             </div>
         </div>

--- a/index.html
+++ b/index.html
@@ -278,8 +278,8 @@
             <div class="row">
                 <div class="col-lg-8 col-lg-offset-2">
                    <p>We're a friendly and inclusive bunch, and we'd like to help you get plugged into a community of people from all kinds of backgrounds who share a common interest in tackling the climate crisis.</p>
-                   <p>To say hi, <a href="https://join.slack.com/t/climate-tech/shared_invite/enQtNDM0MDU3Mzc5Nzc5LTZjOGFkMWY0YTBjYjYzMDdiNWJlMjFkY2Q2MzRiZTFiNzNmNGM4ODI2YTY2ODE4NzgwMmVhYzRkMGIyYTY5YmI">join our <i class="fa fa-slack"></i>Slack</a> and post an intro. If you are not a Slack user, email us at <a href="mailto:hello@climateaction.tech?Subject=Hello!">hello@climateaction.tech</a>. Tell us your name, city, and (optionally) where you work or what you enjoy working on. This is simply to help us get you properly connected in our growing network.</p>
-                   <p>We're excited to hear from you!</p>
+                   <p>To join, sign up <a href="https://docs.google.com/forms/d/e/1FAIpQLSdtvNeUkNkPybk9_Ln5klL1RUPHUCwfK4OfF-odRWnHME9d-g/viewform">here</a>, and we'll add you to the slack community.</p>
+                   <p>If you just want to get in touch, you can also email us at <a href="mailto:hello@climateaction.tech?Subject=Hello!">hello@climateaction.tech</a>. </p>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
This allows us to batch up invites, and have some more control over the onboarding process, so there's a greater chance of people being around to welcome new members, or chat to others.

Admins can still add users manually to slack, if we don't want to wait til the next Monday for people joining.

You can see how it look here on glitch:

https://glitch.com/edit/#!/climate-action-tech-pr-16